### PR TITLE
fix: Destroy sortable instance when disconnected in stimulus

### DIFF
--- a/workflow/app/javascript/controllers/draggable_item_controller.js
+++ b/workflow/app/javascript/controllers/draggable_item_controller.js
@@ -6,9 +6,13 @@ export default class extends Controller {
   static values = { group: String };
 
   connect() {
-    Sortable.create(this.element, {
+    this.sortable = Sortable.create(this.element, {
       group: this.groupValue,
       animation: 150
     })
+  }
+
+  disconnect() {
+    this.sortable.destroy();
   }
 }


### PR DESCRIPTION
This PR destroyed sortable instance when draggable list is disconnected.